### PR TITLE
Move and deselect

### DIFF
--- a/iBMSC/PanelEvents.vb
+++ b/iBMSC/PanelEvents.vb
@@ -263,12 +263,18 @@ Partial Public Class MainWindow
 
 MoveToColumn:   If xTargetColumn = -1 Then Exit Select
                 If Not nEnabled(xTargetColumn) Then Exit Select
+                Dim bDeselectFirstNote = My.Computer.Keyboard.ShiftKeyDown
 
                 For xI2 As Integer = 1 To UBound(Notes)
                     If Not Notes(xI2).Selected Then Continue For
 
                     RedoMoveNote(Notes(xI2), xTargetColumn, Notes(xI2).VPosition, xUndo, xRedo)
                     Notes(xI2).ColumnIndex = xTargetColumn
+
+                    If bDeselectFirstNote Then
+                        bDeselectFirstNote = False
+                        Notes(xI2).Selected = False
+                    End If
                 Next
                 AddUndo(xUndo, xBaseRedo.Next)
                 UpdatePairing()

--- a/iBMSC/PanelEvents.vb
+++ b/iBMSC/PanelEvents.vb
@@ -263,7 +263,7 @@ Partial Public Class MainWindow
 
 MoveToColumn:   If xTargetColumn = -1 Then Exit Select
                 If Not nEnabled(xTargetColumn) Then Exit Select
-                Dim bDeselectFirstNote = My.Computer.Keyboard.ShiftKeyDown
+                Dim bMoveAndDeselectFirstNote = My.Computer.Keyboard.ShiftKeyDown
 
                 For xI2 As Integer = 1 To UBound(Notes)
                     If Not Notes(xI2).Selected Then Continue For
@@ -271,9 +271,9 @@ MoveToColumn:   If xTargetColumn = -1 Then Exit Select
                     RedoMoveNote(Notes(xI2), xTargetColumn, Notes(xI2).VPosition, xUndo, xRedo)
                     Notes(xI2).ColumnIndex = xTargetColumn
 
-                    If bDeselectFirstNote Then
-                        bDeselectFirstNote = False
+                    If bMoveAndDeselectFirstNote Then
                         Notes(xI2).Selected = False
+                        Exit For
                     End If
                 Next
                 AddUndo(xUndo, xBaseRedo.Next)


### PR DESCRIPTION
You can move selected notes using numerical keys, but this moves all the selected note.

This PR makes it so that if you hold down shift, it will only move the first note, and deselects it. This allows you to type the note sequence you want.

![out](https://user-images.githubusercontent.com/193136/33846493-b7c5f144-ded9-11e7-8c22-ed18d023a884.gif)
