### PR TITLE
Play the moved keysound in "move and deselect" mode

### DIFF
--- a/iBMSC/PanelEvents.vb
+++ b/iBMSC/PanelEvents.vb
@@ -273,6 +273,7 @@ MoveToColumn:   If xTargetColumn = -1 Then Exit Select
 
                     If bMoveAndDeselectFirstNote Then
                         Notes(xI2).Selected = False
+                        PanelPreviewNoteIndex(xI2)
                         Exit For
                     End If
                 Next


### PR DESCRIPTION
In “move and deselect” mode, it can be useful to play the keysound after moving.